### PR TITLE
[feat #13] 알라딘 Open API 추가 데이터 저장 및 카테고리 저장 방식 변경

### DIFF
--- a/src/main/java/com/umc/ttt/domain/book/controller/BookRestController.java
+++ b/src/main/java/com/umc/ttt/domain/book/controller/BookRestController.java
@@ -17,9 +17,9 @@ public class BookRestController {
     private final BookCommandService bookCommandService;
 
     @PostMapping("/fetch")
-    @Operation(summary = "알라딘 Open API 데이터 저장")
-    public ApiResponse<List<BookResponseDTO.Item>> fetchBooks() {
-        List<BookResponseDTO.Item> books = bookCommandService.fetchBooks();
-        return ApiResponse.onSuccess(books);
+    @Operation(summary = "알라딘 Open API 데이터 저장", description = "서버 테스트용 api입니다. 연동x")
+    public ApiResponse<String> fetchBooks() {
+        bookCommandService.fetchBooks();
+        return ApiResponse.onSuccess("알라딘 Open API 데이터가 저장되었습니다.");
     }
 }

--- a/src/main/java/com/umc/ttt/domain/book/converter/BookConverter.java
+++ b/src/main/java/com/umc/ttt/domain/book/converter/BookConverter.java
@@ -2,10 +2,11 @@ package com.umc.ttt.domain.book.converter;
 
 import com.umc.ttt.domain.book.dto.BookResponseDTO;
 import com.umc.ttt.domain.book.entity.Book;
+import com.umc.ttt.domain.book.entity.BookCategory;
 
 public class BookConverter {
 
-    public static Book toEntity(BookResponseDTO.Item item) {
+    public static Book toEntity(BookResponseDTO.Item item, BookCategory bookCategory) {
         return Book.builder()
                 .title(item.getTitle())
                 .author(item.getAuthor())
@@ -13,9 +14,11 @@ public class BookConverter {
                 .cover(item.getCover())
                 .description(item.getDescription())
                 .publisher(item.getPublisher())
-                .categoryName(item.getCategoryName())
                 .bestRank(item.getBestRank())
                 .link(item.getLink())
+                .itemPage(item.getItemPage())
+                .hasEbook(item.isHasEbook())
+                .bookCategory(bookCategory)
                 .build();
     }
 }

--- a/src/main/java/com/umc/ttt/domain/book/dto/BookResponseDTO.java
+++ b/src/main/java/com/umc/ttt/domain/book/dto/BookResponseDTO.java
@@ -1,5 +1,7 @@
 package com.umc.ttt.domain.book.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.umc.ttt.domain.book.entity.BookCategory;
 import lombok.*;
 
 import java.util.List;
@@ -24,6 +26,7 @@ public class BookResponseDTO {
 
     @Builder
     @Getter
+    @Setter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Item {
@@ -31,10 +34,26 @@ public class BookResponseDTO {
         private String author;
         private String cover;
         private String isbn;
-        private String categoryName;
         private String publisher;
         private String description;
         private String bestRank;
         private String link;
+        private int itemPage;
+        private boolean hasEbook;
+        private BookCategory category;
+
+        @JsonProperty("subInfo")
+        private void unpackSubInfo(SubInfo subInfo) {
+            this.hasEbook = subInfo != null && subInfo.getEbookList() != null && !subInfo.getEbookList().isEmpty();
+            this.itemPage = subInfo.getItemPage();
+        }
+
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class SubInfo {
+            private int itemPage;
+            private List<?> ebookList;
+        }
     }
 }

--- a/src/main/java/com/umc/ttt/domain/book/entity/Book.java
+++ b/src/main/java/com/umc/ttt/domain/book/entity/Book.java
@@ -46,13 +46,14 @@ public class Book {
     private double rating;  // 평점
 
     @Column(nullable = false)
-    private String categoryName;    // 카테고리
-
-    @Column(nullable = false)
     private String link;    // 상품 링크
 
     // 프리미엄 데이터
     private String toc; // 목차
 
     private String publisherDescription;    // 출판사 제공 책소개
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_category_id")
+    private BookCategory bookCategory;
 }

--- a/src/main/java/com/umc/ttt/domain/book/entity/BookCategory.java
+++ b/src/main/java/com/umc/ttt/domain/book/entity/BookCategory.java
@@ -1,0 +1,20 @@
+package com.umc.ttt.domain.book.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+public class BookCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "book_category_id", nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private String categoryName;
+}

--- a/src/main/java/com/umc/ttt/domain/book/repository/BookCategoryRepository.java
+++ b/src/main/java/com/umc/ttt/domain/book/repository/BookCategoryRepository.java
@@ -1,0 +1,8 @@
+package com.umc.ttt.domain.book.repository;
+
+import com.umc.ttt.domain.book.entity.BookCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookCategoryRepository extends JpaRepository<BookCategory, Long> {
+    boolean existsByCategoryName(String categoryName);
+}

--- a/src/main/java/com/umc/ttt/domain/book/service/BookCommandService.java
+++ b/src/main/java/com/umc/ttt/domain/book/service/BookCommandService.java
@@ -1,9 +1,5 @@
 package com.umc.ttt.domain.book.service;
 
-import com.umc.ttt.domain.book.dto.BookResponseDTO;
-
-import java.util.List;
-
 public interface BookCommandService {
-    public List<BookResponseDTO.Item> fetchBooks();
+    public void fetchBooks();
 }

--- a/src/main/java/com/umc/ttt/domain/book/service/BookCommandServiceImpl.java
+++ b/src/main/java/com/umc/ttt/domain/book/service/BookCommandServiceImpl.java
@@ -3,6 +3,8 @@ package com.umc.ttt.domain.book.service;
 import com.umc.ttt.domain.book.converter.BookConverter;
 import com.umc.ttt.domain.book.dto.BookResponseDTO;
 import com.umc.ttt.domain.book.entity.Book;
+import com.umc.ttt.domain.book.entity.BookCategory;
+import com.umc.ttt.domain.book.repository.BookCategoryRepository;
 import com.umc.ttt.domain.book.repository.BookRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +21,7 @@ import java.util.stream.Collectors;
 public class BookCommandServiceImpl implements BookCommandService {
 
     private final BookRepository bookRepository;
+    private final BookCategoryRepository bookCategoryRepository;
     private final RestTemplate restTemplate = new RestTemplate();
 
     @Value("${aladin.api.base-url}")
@@ -27,12 +30,17 @@ public class BookCommandServiceImpl implements BookCommandService {
     @Value("${aladin.api.query-params}")
     private String queryParams;
 
+    @Value("${aladin.api.item-lookup-url}")
+    private String itemLookupUrl;
+
+    @Value("${aladin.api.item-query-params}")
+    private String itemQueryParams;
+
     @Value("${aladin.api.ttbkey}")
     private String ttbkey;
 
-    @Override
     @Transactional
-    public List<BookResponseDTO.Item> fetchBooks() {
+    public void fetchBooks() {
         if (ttbkey == null) {
             throw new RuntimeException("환경변수 ALADIN_TTBKEY가 설정되어 있지 않습니다.");
         }
@@ -41,10 +49,20 @@ public class BookCommandServiceImpl implements BookCommandService {
         int maxResults = 50;
         int startPage = 1;
 
-        // CategoryId 목록 (판타지, 미스터리, 고전, 성장, 심리학, 비즈니스, 역사, 논리, 로맨스, 감성, 힐링, 종교학, 문화, 철학, 예술)
-        List<Integer> categoryIds = List.of(50928, 152930, 103639, 336, 51395, 2172, 74, 51412, 50935, 50917, 70236, 1237, 2177, 51387, 517);
+        // CategoryId 목록
+        // 과학, 여행에세이, 외국문학, 시, 장르소설, 자기계발, 인문, 소설
+        // 판타지, 미스터리, 고전, 성장, 심리학, 비즈니스, 역사, 논리, 로맨스, 감성, 힐링, 종교학, 문화, 철학, 예술
+        List<Integer> categoryIds = List.of(987, 51377, 50955, 50940, 112011, 336, 656, 1,
+                50928, 50926, 103639, 51235, 51395, 2172, 74, 51412, 50935, 50917, 70236, 1237, 2177, 51387, 517);
 
-        for (int categoryId : categoryIds) {
+        for (int i = 0; i < categoryIds.size(); i++) {
+            int categoryId = categoryIds.get(i);
+            int bookCategoryId = i + 1;
+
+            BookCategory bookCategory = bookCategoryRepository.findById((long) bookCategoryId)
+                    .orElseThrow(() -> new RuntimeException("BookCategoryId " + bookCategoryId + "를 찾을 수 없습니다."));
+
+
             String apiUrl = String.format(baseUrl + queryParams + "&CategoryId=%d", ttbkey, maxResults, startPage, categoryId);
 
             BookResponseDTO response = restTemplate.getForObject(apiUrl, BookResponseDTO.class);
@@ -54,14 +72,22 @@ public class BookCommandServiceImpl implements BookCommandService {
                 continue;
             }
 
-            allItems.addAll(response.getItem());
+            for (BookResponseDTO.Item item : response.getItem()) {
+                String lookupUrl = String.format(itemLookupUrl + itemQueryParams, ttbkey, item.getIsbn());
+                BookResponseDTO lookupResponse = restTemplate.getForObject(lookupUrl, BookResponseDTO.class);
 
-            List<Book> books = response.getItem().stream()
-                    .map(BookConverter::toEntity)
-                    .collect(Collectors.toList());
-            bookRepository.saveAll(books);
+                if (lookupResponse != null && lookupResponse.getItem() != null && !lookupResponse.getItem().isEmpty()) {
+                    BookResponseDTO.Item lookupItem = lookupResponse.getItem().get(0);
+
+                    item.setItemPage(lookupItem.getItemPage());
+                    item.setHasEbook(lookupItem.isHasEbook());
+                }
+
+                allItems.add(item);
+
+                Book bookEntity = BookConverter.toEntity(item, bookCategory);
+                bookRepository.save(bookEntity);
+            }
         }
-
-        return allItems;
     }
 }

--- a/src/main/java/com/umc/ttt/global/config/BookCategoryInitializer.java
+++ b/src/main/java/com/umc/ttt/global/config/BookCategoryInitializer.java
@@ -1,0 +1,37 @@
+package com.umc.ttt.global.config;
+
+import com.umc.ttt.domain.book.entity.BookCategory;
+import com.umc.ttt.domain.book.repository.BookCategoryRepository;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class BookCategoryInitializer {
+
+    @Autowired
+    private BookCategoryRepository bookCategoryRepository;
+
+    @PostConstruct
+    public void initializeCategories() {
+        List<String> defaultCategories = Arrays.asList(
+                "과학", "여행에세이", "외국문학", "시", "장르소설",
+                "자기계발", "인문", "소설", "판타지", "미스터리",
+                "고전", "성장", "심리학", "비즈니스", "역사",
+                "논리", "로맨스", "감성", "힐링", "종교학",
+                "문화", "철학", "예술"
+        );
+
+        for (String categoryName : defaultCategories) {
+            if (!bookCategoryRepository.existsByCategoryName(categoryName)) {
+                BookCategory category = BookCategory.builder()
+                        .categoryName(categoryName)
+                        .build();
+                bookCategoryRepository.save(category);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #13

## 📝 작업 내용
-  알라딘 상품 조회 API 가져오기
-  카테고리 엔티티 생성 및 매핑

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   
- BookCategory와 Member 매핑은 추가적으로 필요합니다!

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
