### PR TITLE
[feat #51] 공간 에디터 픽 api 구현

### DIFF
--- a/src/main/java/com/umc/ttt/domain/place/controller/PlaceRestController.java
+++ b/src/main/java/com/umc/ttt/domain/place/controller/PlaceRestController.java
@@ -104,4 +104,12 @@ public class PlaceRestController {
         Member member = memberRepository.findById(1L).get();
         return ApiResponse.onSuccess(placeQueryService.suggestPlaces(member));
     }
+
+    @GetMapping("/editor-pick")
+    @Operation(summary = "공간 에디터 픽", description = "에디터가 픽한 공간 5곳을 반환합니다.")
+    public ApiResponse<PlaceResponseDTO.EditorPickPlaceListDTO> getEditorPickPlaces() {
+        // TODO: 로그인한 회원 정보로 변경
+        Member member = memberRepository.findById(1L).get();
+        return ApiResponse.onSuccess(placeQueryService.getEditorPickPlaces(member));
+    }
 }

--- a/src/main/java/com/umc/ttt/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/com/umc/ttt/domain/place/converter/PlaceConverter.java
@@ -81,4 +81,25 @@ public class PlaceConverter {
                 .places(placePreviewDTOs)
                 .build();
     }
+
+    public static PlaceResponseDTO.EditorPickPlaceDTO toEditorPickPlaceDTO(Place place, boolean isScraped) {
+        return PlaceResponseDTO.EditorPickPlaceDTO.builder()
+                .placeId(place.getId())
+                .title(place.getTitle())
+                .category(place.getCategory())
+                .image(place.getImage())
+                .curationTitle(place.getCurationTitle())
+                .isScraped(isScraped)
+                .build();
+    }
+
+    public static PlaceResponseDTO.EditorPickPlaceListDTO toEditorPickPlaceListDTO(List<Place> places, List<Long> scrapedPlaceIds) {
+        List<PlaceResponseDTO.EditorPickPlaceDTO> editorPickPlaceDTOS = places.stream()
+                .map(place -> toEditorPickPlaceDTO(place, scrapedPlaceIds.contains(place.getId())))
+                .toList();
+
+        return PlaceResponseDTO.EditorPickPlaceListDTO.builder()
+                .places(editorPickPlaceDTOS)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/ttt/domain/place/dto/PlaceResponseDTO.java
+++ b/src/main/java/com/umc/ttt/domain/place/dto/PlaceResponseDTO.java
@@ -69,4 +69,20 @@ public class PlaceResponseDTO {
         private List<PlacePreviewDTO> places;
     }
 
+    @Builder
+    @Getter
+    public static class EditorPickPlaceDTO {
+        private Long placeId;
+        private String title;
+        private PlaceCategory category;
+        private String image;
+        private String curationTitle;
+        private boolean isScraped;
+    }
+
+    @Builder
+    @Getter
+    public static class EditorPickPlaceListDTO {
+        private List<EditorPickPlaceDTO> places;
+    }
 }

--- a/src/main/java/com/umc/ttt/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/umc/ttt/domain/place/repository/PlaceRepository.java
@@ -76,4 +76,6 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     List<Place> findPlacesByCategory(PlaceCategory placeCategory);
     List<Place> findAllByIdGreaterThanEqual(long l);
+
+    Place findPlaceByTitle(String title);
 }

--- a/src/main/java/com/umc/ttt/domain/place/service/PlaceQueryService.java
+++ b/src/main/java/com/umc/ttt/domain/place/service/PlaceQueryService.java
@@ -11,4 +11,6 @@ public interface PlaceQueryService {
     PlaceResponseDTO.PlaceListDTO searchPlaceList(String keyword, Long cursor, int limit, Member member);
 
     PlaceResponseDTO.PlaceSuggestListDTO suggestPlaces(Member member);
+
+    PlaceResponseDTO.EditorPickPlaceListDTO getEditorPickPlaces(Member member);
 }

--- a/src/main/java/com/umc/ttt/domain/place/service/impl/PlaceQueryServiceImpl.java
+++ b/src/main/java/com/umc/ttt/domain/place/service/impl/PlaceQueryServiceImpl.java
@@ -17,9 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -122,6 +120,21 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
         List<Long> scrapedPlaceIds = placeScrapRepository.findScrapedPlaceIdsByMemberAndPlaces(member, randomPlaces);
 
         return PlaceConverter.toPlaceSuggestListDTO(randomPlaces, scrapedPlaceIds);
+    }
+
+    @Override
+    public PlaceResponseDTO.EditorPickPlaceListDTO getEditorPickPlaces(Member member) {
+        // 에디터 픽 공간 5곳 - 로이 픽
+        List<String> titles = Arrays.asList("북앤드로잉", "유어마인드", "북파크", "땡스북스", "책방오늘");
+
+        List<Place> places = titles.stream()
+                .map(placeRepository::findPlaceByTitle)
+                .filter(Objects::nonNull)
+                .toList();
+
+        List<Long> scrapedPlaceIds = placeScrapRepository.findScrapedPlaceIdsByMemberAndPlaces(member, places);
+
+        return PlaceConverter.toEditorPickPlaceListDTO(places, scrapedPlaceIds);
     }
 
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #51

## 📝 작업 내용
-   [공간 에디터 픽 api 구현](https://github.com/UMC-7th-Ttt/Ttt_BE/commit/3b88161f53ef24724b28e93744e68d9cf4c46d08)

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   
- 원래 최신 순 5개 생각했다가 책마다 북클럽처럼 에티터가 달마다 선정하는 방식로 바꿀까 생각 중이라 하셨는데
공간은 북레터가 있는 것도 아니고.. 해서 일단 로이 픽으로 구현했어요
## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
