### PR TITLE
[feat] CurrentMember 어노테이션으로 로그인한 멤버 정보 가져오기

### DIFF
--- a/src/main/java/com/umc/ttt/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/umc/ttt/domain/member/service/MemberCommandServiceImpl.java
@@ -5,6 +5,8 @@ import com.umc.ttt.domain.member.entity.Member;
 import com.umc.ttt.domain.member.entity.enums.ProviderType;
 import com.umc.ttt.domain.member.entity.enums.Role;
 import com.umc.ttt.domain.member.repository.MemberRepository;
+import com.umc.ttt.domain.scrap.entity.ScrapFolder;
+import com.umc.ttt.domain.scrap.repository.ScrapFolderRepository;
 import com.umc.ttt.global.apiPayload.code.status.ErrorStatus;
 import com.umc.ttt.global.apiPayload.exception.GeneralException;
 import com.umc.ttt.global.apiPayload.exception.handler.JwtHandler;
@@ -18,6 +20,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -29,6 +33,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
     private final RefreshTokenRepository tokenRepository;
+    private final ScrapFolderRepository scrapFolderRepository;
 
     @Override
     public void signUp(MemberSignUpDTO memberSignUpDto) throws Exception {
@@ -58,6 +63,14 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         member.passwordEncode(passwordEncoder);
         memberRepository.save(member);
+
+        // 기본 스크랩 폴더 생성
+        List<ScrapFolder> scrapFolders = Arrays.asList(
+                ScrapFolder.builder().name("공간").member(member).build(),
+                ScrapFolder.builder().name("도서").member(member).build()
+        );
+
+        scrapFolderRepository.saveAll(scrapFolders);
     }
 
     @Override

--- a/src/main/java/com/umc/ttt/domain/place/controller/PlaceRestController.java
+++ b/src/main/java/com/umc/ttt/domain/place/controller/PlaceRestController.java
@@ -1,13 +1,13 @@
 package com.umc.ttt.domain.place.controller;
 
 import com.umc.ttt.domain.member.entity.Member;
-import com.umc.ttt.domain.member.repository.MemberRepository;
 import com.umc.ttt.domain.place.dto.PlaceRequestDTO;
 import com.umc.ttt.domain.place.dto.PlaceResponseDTO;
 import com.umc.ttt.domain.place.service.PlaceApiService;
 import com.umc.ttt.domain.place.service.PlaceCommandService;
 import com.umc.ttt.domain.place.service.PlaceImageCrawlingService;
 import com.umc.ttt.domain.place.service.PlaceQueryService;
+import com.umc.ttt.global.annotation.CurrentMember;
 import com.umc.ttt.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -24,7 +24,6 @@ public class PlaceRestController {
     private final PlaceApiService placeApiService;
     private final PlaceCommandService placeCommandService;
     private final PlaceQueryService placeQueryService;
-    private final MemberRepository memberRepository;
     private final PlaceImageCrawlingService placeImageCrawlingService;
 
     @PostMapping
@@ -52,17 +51,14 @@ public class PlaceRestController {
     @PatchMapping("/{placeId}/curations")
     @Operation(summary = "공간 큐레이션 작성, 수정", description = "관리자만 작성 및 수정 가능합니다. 삭제의 경우 빈 문자열을 전달해주세요.")
     public ApiResponse<PlaceResponseDTO.CurationDTO> updateCuration(@PathVariable(name = "placeId") Long placeId,
-                                                                    @Valid @RequestBody PlaceRequestDTO.CurationDTO curationDTO) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+                                                                    @Valid @RequestBody PlaceRequestDTO.CurationDTO curationDTO,
+                                                                    @CurrentMember Member member) {
         return ApiResponse.onSuccess(placeCommandService.updateCuration(placeId, curationDTO, member));
     }
 
     @GetMapping("/{placeId}")
     @Operation(summary = "공간 상세 조회")
-    public ApiResponse<PlaceResponseDTO.PlaceDTO> getPlace(@PathVariable(name = "placeId") Long placeId) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+    public ApiResponse<PlaceResponseDTO.PlaceDTO> getPlace(@PathVariable(name = "placeId") Long placeId, @CurrentMember Member member) {
         return ApiResponse.onSuccess(placeQueryService.getPlace(placeId, member));
     }
 
@@ -76,12 +72,11 @@ public class PlaceRestController {
             @Parameter(name = "sort", description = "전체: all, 서점: bookstore, 북카페: cafe"),
     })
     public ApiResponse<PlaceResponseDTO.PlaceListDTO> getPlaceList(@RequestParam(name = "lat", required = false) Double lat,
-                                                                    @RequestParam(name = "lon", required = false) Double lon,
-                                                                    @RequestParam(name = "sort", defaultValue = "all") String sort,
-                                                                    @RequestParam(name = "cursor", defaultValue = "0") Long cursor,
-                                                                    @RequestParam(name = "limit", defaultValue = "10") int limit) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+                                                                   @RequestParam(name = "lon", required = false) Double lon,
+                                                                   @RequestParam(name = "sort", defaultValue = "all") String sort,
+                                                                   @RequestParam(name = "cursor", defaultValue = "0") Long cursor,
+                                                                   @RequestParam(name = "limit", defaultValue = "10") int limit,
+                                                                   @CurrentMember Member member) {
         return ApiResponse.onSuccess(placeQueryService.getPlaceList(lat, lon, sort, cursor, limit, member));
     }
 
@@ -91,25 +86,20 @@ public class PlaceRestController {
             "첫 페이지가 아닌 경우 이전 응답의 hasNext가 true일 때, nextCursor 값을 cursor로 전달해주세요.")
     public ApiResponse<PlaceResponseDTO.PlaceListDTO> searchPlaceList(@RequestParam(name = "keyword") String keyword,
                                                                       @RequestParam(name = "cursor", defaultValue = "0") Long cursor,
-                                                                      @RequestParam(name = "limit", defaultValue = "10") int limit) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+                                                                      @RequestParam(name = "limit", defaultValue = "10") int limit,
+                                                                      @CurrentMember Member member) {
         return ApiResponse.onSuccess(placeQueryService.searchPlaceList(keyword, cursor, limit, member));
     }
 
     @GetMapping("/suggestions")
     @Operation(summary = "공간 추천", description = "사용자가 선호하는 공간 카테고리를 기반으로 공간을 추천합니다. 추천 결과로 10개의 공간을 반환합니다.")
-    public ApiResponse<PlaceResponseDTO.PlaceSuggestListDTO> suggestPlaces() {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+    public ApiResponse<PlaceResponseDTO.PlaceSuggestListDTO> suggestPlaces(@CurrentMember Member member) {
         return ApiResponse.onSuccess(placeQueryService.suggestPlaces(member));
     }
 
     @GetMapping("/editor-pick")
     @Operation(summary = "공간 에디터 픽", description = "에디터가 픽한 공간 5곳을 반환합니다.")
-    public ApiResponse<PlaceResponseDTO.EditorPickPlaceListDTO> getEditorPickPlaces() {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+    public ApiResponse<PlaceResponseDTO.EditorPickPlaceListDTO> getEditorPickPlaces(@CurrentMember Member member) {
         return ApiResponse.onSuccess(placeQueryService.getEditorPickPlaces(member));
     }
 }

--- a/src/main/java/com/umc/ttt/domain/scrap/controller/ScrapRestController.java
+++ b/src/main/java/com/umc/ttt/domain/scrap/controller/ScrapRestController.java
@@ -1,13 +1,12 @@
 package com.umc.ttt.domain.scrap.controller;
 
 import com.umc.ttt.domain.member.entity.Member;
-import com.umc.ttt.domain.member.repository.MemberRepository;
 import com.umc.ttt.domain.scrap.dto.ScrapRequestDTO;
 import com.umc.ttt.domain.scrap.dto.ScrapResponseDTO;
 import com.umc.ttt.domain.scrap.service.ScrapCommandService;
 import com.umc.ttt.domain.scrap.service.ScrapQueryService;
+import com.umc.ttt.global.annotation.CurrentMember;
 import com.umc.ttt.global.apiPayload.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -20,15 +19,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api")
 public class ScrapRestController {
 
-    private final MemberRepository memberRepository;
     private final ScrapCommandService scrapCommandService;
     private final ScrapQueryService scrapQueryService;
 
     @GetMapping("/scraps/folders")
     @Operation(summary = "스크랩 폴더 목록 조회 - 마이페이지", description = "도서, 공간은 기본 폴더입니다.")
-    public ApiResponse<ScrapResponseDTO.ScrapFolderListDTO> getScrapFolders() {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+    public ApiResponse<ScrapResponseDTO.ScrapFolderListDTO> getScrapFolders(@CurrentMember Member member) {
         return ApiResponse.onSuccess(scrapQueryService.getScrapFolders(member));
     }
 
@@ -37,27 +33,22 @@ public class ScrapRestController {
             "첫 페이지 조회 시 각 cursor 값으로 0을 전달해주세요.\n\n" +
             "첫 페이지가 아닌 경우 이전 응답의 hasNext가 true일 때, nextBookCursor, nextPlaceCursor 값을 각 cursor로 전달해주세요.")
     public ApiResponse<ScrapResponseDTO.ScrapListDTO> getScrapList(@PathVariable(name = "folderId") Long folderId,
-                                                                           @RequestParam(name = "bookCursor", required = false) Long bookCursor,
-                                                                           @RequestParam(name = "placeCursor", required = false) Long placeCursor,
-                                                                           @RequestParam(name = "limit", defaultValue = "10") int limit) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+                                                                   @RequestParam(name = "bookCursor", required = false) Long bookCursor,
+                                                                   @RequestParam(name = "placeCursor", required = false) Long placeCursor,
+                                                                   @RequestParam(name = "limit", defaultValue = "10") int limit,
+                                                                   @CurrentMember Member member) {
         return ApiResponse.onSuccess(scrapQueryService.getScrapList(folderId, bookCursor, placeCursor, limit, member));
     }
 
     @PostMapping("/scraps/folders")
     @Operation(summary = "스크랩 폴더 생성 - 마이페이지", description = "마이페이지에서 스크랩 폴더 생성 시 사용되는 api입니다.")
-    public ApiResponse<ScrapResponseDTO.ScrapFolderDTO> createScrapFolder(@RequestParam(name = "folder") String folder) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+    public ApiResponse<ScrapResponseDTO.ScrapFolderDTO> createScrapFolder(@RequestParam(name = "folder") String folder, @CurrentMember Member member) {
         return ApiResponse.onSuccess(scrapCommandService.createScrapFolder(folder, member));
     }
 
     @DeleteMapping("/scraps/folders/{folderId}")
-    @Operation(summary = "스크랩 폴더 삭제", description = "폴더의 스크랩 내역까지 모두 삭제됩니다. 기본 폴더(도서, 공간)는 삭제할 수 없습니다.")
-    public ApiResponse<Long> deleteScrapFolder(@PathVariable(name = "folderId") Long folderId) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+    @Operation(summary = "스크랩 폴더 삭제 - 마이페이지", description = "폴더의 스크랩 내역까지 모두 삭제됩니다. 기본 폴더(도서, 공간)는 삭제할 수 없습니다.")
+    public ApiResponse<Long> deleteScrapFolder(@PathVariable(name = "folderId") Long folderId, @CurrentMember Member member) {
         return ApiResponse.onSuccess(scrapCommandService.deleteScrapFolder(folderId, member));
     }
 
@@ -67,17 +58,13 @@ public class ScrapRestController {
             @Parameter(name = "folder", description = "폴더 이름(ex. 공간)"),
     })
     public ApiResponse<ScrapResponseDTO.PlaceScrapDTO> addScrap(@PathVariable(name = "placeId") Long placeId,
-                                                                @RequestParam(name = "folder") String folder) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+                                                                @RequestParam(name = "folder") String folder, @CurrentMember Member member) {
         return ApiResponse.onSuccess(scrapCommandService.addPlaceScrap(placeId, folder, member));
     }
 
     @DeleteMapping("/places/{placeId}/scraps")
     @Operation(summary = "공간 스크랩 취소")
-    public ApiResponse<ScrapResponseDTO.PlaceScrapDTO> removeScrap(@PathVariable(name = "placeId") Long placeId) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+    public ApiResponse<ScrapResponseDTO.PlaceScrapDTO> removeScrap(@PathVariable(name = "placeId") Long placeId, @CurrentMember Member member) {
         return ApiResponse.onSuccess(scrapCommandService.removePlaceScrap(placeId, member));
     }
 
@@ -87,17 +74,13 @@ public class ScrapRestController {
             @Parameter(name = "folder", description = "폴더 이름(ex. 도서)"),
     })
     public ApiResponse<ScrapResponseDTO.BookScrapDTO> addBookScrap(@PathVariable(name = "bookId") Long bookId,
-                                                                   @RequestParam(name = "folder") String folder) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+                                                                   @RequestParam(name = "folder") String folder, @CurrentMember Member member) {
         return ApiResponse.onSuccess(scrapCommandService.addBookScrap(bookId, folder, member));
     }
 
     @DeleteMapping("/books/{bookId}/scraps")
     @Operation(summary = "책 스크랩 취소")
-    public ApiResponse<ScrapResponseDTO.BookScrapDTO> removeBookScrap(@PathVariable(name = "bookId") Long bookId) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+    public ApiResponse<ScrapResponseDTO.BookScrapDTO> removeBookScrap(@PathVariable(name = "bookId") Long bookId, @CurrentMember Member member) {
         return ApiResponse.onSuccess(scrapCommandService.removeBookScrap(bookId, member));
     }
 
@@ -106,9 +89,8 @@ public class ScrapRestController {
             "삭제하려는 스크랩의 id와 type(PLACE 또는 BOOK)을 전달해주세요.\n\n" +
             "스크랩 목록 조회 API 응답의 'id'와 'type'을 사용하여 삭제할 항목을 지정할 수 있습니다.")
     public ApiResponse<ScrapResponseDTO.ScrapListDTO> removeMultipleScraps(@PathVariable(name = "folderId") Long folderId,
-                                                                           @Valid @RequestBody ScrapRequestDTO.ScrapRemoveRequestDTO scrapRemoveRequestDTO) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+                                                                           @Valid @RequestBody ScrapRequestDTO.ScrapRemoveRequestDTO scrapRemoveRequestDTO,
+                                                                           @CurrentMember Member member) {
         scrapCommandService.removeScraps(scrapRemoveRequestDTO);
         // 삭제 후 최신 스크랩 목록 반환
         ScrapResponseDTO.ScrapListDTO updatedScrapList = scrapQueryService.getScrapList(
@@ -119,9 +101,8 @@ public class ScrapRestController {
     @PatchMapping("/scraps/folders/{folderId}")
     @Operation(summary = "스크랩 폴더 이동 - 마이페이지", description = "마이페이지에서 하나 이상의 스크랩 내역을 다른 폴더로 이동합니다.")
     public ApiResponse<Void> moveScrapFolder(@PathVariable(name = "folderId") Long folderId,
-                                             @Valid @RequestBody ScrapRequestDTO.ScrapFolderMoveRequestDTO scrapFolderMoveRequestDTO) {
-        // TODO: 로그인한 회원 정보로 변경
-        Member member = memberRepository.findById(1L).get();
+                                             @Valid @RequestBody ScrapRequestDTO.ScrapFolderMoveRequestDTO scrapFolderMoveRequestDTO,
+                                             @CurrentMember Member member) {
         scrapCommandService.moveScrapFolder(folderId, scrapFolderMoveRequestDTO, member);
         return ApiResponse.onSuccess(null);
     }

--- a/src/main/java/com/umc/ttt/global/annotation/CurrentMember.java
+++ b/src/main/java/com/umc/ttt/global/annotation/CurrentMember.java
@@ -1,0 +1,11 @@
+package com.umc.ttt.global.annotation;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
+public @interface CurrentMember {
+}

--- a/src/main/java/com/umc/ttt/global/annotation/CurrentMemberArgumentResolver.java
+++ b/src/main/java/com/umc/ttt/global/annotation/CurrentMemberArgumentResolver.java
@@ -1,0 +1,43 @@
+package com.umc.ttt.global.annotation;
+
+import com.umc.ttt.domain.member.entity.Member;
+import com.umc.ttt.domain.member.repository.MemberRepository;
+import com.umc.ttt.global.apiPayload.code.status.ErrorStatus;
+import com.umc.ttt.global.apiPayload.exception.handler.JwtHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean parameterAnnotation = parameter.hasParameterAnnotation(CurrentMember.class);
+        boolean memberParameterType = parameter.getParameterType().isAssignableFrom(Member.class);
+        return parameterAnnotation && memberParameterType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            String email = authentication.getName(); // 인증된 사용자 이메일
+            return memberRepository.findByEmail(email)
+                    .orElseThrow(() -> new JwtHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/com/umc/ttt/global/config/WebConfig.java
+++ b/src/main/java/com/umc/ttt/global/config/WebConfig.java
@@ -1,11 +1,24 @@
 package com.umc.ttt.global.config;
 
+import com.umc.ttt.global.annotation.CurrentMemberArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentMemberArgumentResolver currentMemberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentMemberArgumentResolver);
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #이슈번호

## 📝 작업 내용
-   [CurrentMember 어노테이션으로 로그인한 멤버 가져오기](https://github.com/UMC-7th-Ttt/Ttt_BE/commit/3c4e247f651967aa09f40c3d02e68650d73680b0)
- [place, scrap 하드코딩된 멤버 실제 로그인한 멤버 정보로 변경](https://github.com/UMC-7th-Ttt/Ttt_BE/commit/1ad37b0be48b9cfe11fb5ceeba342861fd60fbda)
- [회원가입 시 기본 스크랩 폴더(공간, 도서) 생성](https://github.com/UMC-7th-Ttt/Ttt_BE/commit/2cce4ca3393f06d40bc31440dadf5761f4198493)

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   
- 컨트롤러에서 `@CurrentMember Member member` 를 사용하여 로그인한 멤버 객체를 파라미터로 받고, 서비스로 전달해서 필요한 로직 처리하면 됩니다. 
## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
