### PR TITLE
[fix #75] 책마다 북클럽 상세 페이지 조회 예외 처리 수정

### DIFF
--- a/src/main/java/com/umc/ttt/domain/bookClub/service/BookClubQueryServiceImpl.java
+++ b/src/main/java/com/umc/ttt/domain/bookClub/service/BookClubQueryServiceImpl.java
@@ -27,6 +27,7 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -64,16 +65,17 @@ public class BookClubQueryServiceImpl implements BookClubQueryService {
         BookClubMember bookClubMember = bookClubMemberRepository.findByBookClubAndMember(bookClub, member)
                 .orElseThrow(() -> new BookClubHandler(ErrorStatus.MEMBER_NOT_FOUND_IN_BOOK_CLUB));
 
-        List<ReadingRecord> readingRecords = readingRecordRepository.findByBookClubMember(bookClubMember);
-        ReadingRecord readingRecord = readingRecords.stream()
-                .max(Comparator.comparing(ReadingRecord::getCreatedAt)) // 가장 최근 인증 선택
-                .orElseThrow(() -> new BookClubHandler(ErrorStatus.READING_RECORD_NOT_FOUND));
+        Optional<ReadingRecord> latestReadingRecord = readingRecordRepository.findByBookClubMember(bookClubMember)
+                .stream()
+                .max(Comparator.comparing(ReadingRecord::getCreatedAt));
 
         // 오늘 날짜 기준 경과 주 계산
         int elapsedWeeks = calculateElapsedWeeks(bookClub.getStartDate(), 4);
 
         // 완독률 계산
-        int myCompletionRate = calculateUserCompletionRate(readingRecord.getCurrentPage(), book.getItemPage());
+        int myCompletionRate = latestReadingRecord
+                .map(record -> calculateUserCompletionRate(record.getCurrentPage(), book.getItemPage()))
+                .orElse(0);
         int recommendedCompletionRate = calculateRecommendedCompletionRate(book.getItemPage(), 4, bookClub.getStartDate());
 
         return BookClubConverter.toGetBookClubDetailsResultDTO(bookClub, bookInfoDTO, memberInfoDTOList, elapsedWeeks, myCompletionRate, recommendedCompletionRate);


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #75

## 📝 작업 내용
-   책마다 북클럽 상세 페이지 조회 시 참여 인증 없을 경우, 예외 처리하지 않고 myCompletionRate가 0 반환하도록 함

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
