### PR TITLE
[fix #100] 유저 정보 수정 & 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/ttt/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/ttt/domain/member/controller/MemberController.java
@@ -121,17 +121,31 @@ public class MemberController {
         return ApiResponse.onSuccess("선호 카테고리 저장 완료");
     }
 
-    @PostMapping(value = "/users/profile", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/users", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @Operation(summary = "nickname, profile 저장", description = "nickname, profile 저장. 로그인 전으로 memberId를 활용해주세요")
-    public ApiResponse<MemberResponseDTO.MemberProfileDTO> saveProfile(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) @RequestPart @Valid MemberAddProfileDTO requestDTO, @RequestPart("profilePicture") MultipartFile profilePicture) throws Exception {
+    public ApiResponse<MemberResponseDTO.MemberProfileDTO2> saveProfile(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) @RequestPart @Valid MemberAddProfileDTO requestDTO, @RequestPart("profilePicture") MultipartFile profilePicture) throws Exception {
         Member member= memberCommandService.saveProfile(requestDTO, profilePicture);
         return ApiResponse.onSuccess(MemberConverter.toMemberProfileDTO(member));
     }
 
-    @PatchMapping("/users")
-    @Operation(summary = "nickname, profile, password 변경", description = "nickname, profile, password 변경하는 API입니다.")
-    public ApiResponse<MemberResponseDTO.MemberProfileDTO> updateInfo(@CurrentMember Member member, @Valid @RequestBody MemberUpdateInfoDTO requestDTO) throws Exception {
-        return ApiResponse.onSuccess(MemberConverter.toMemberProfileDTO(memberCommandService.updateInfo(member, requestDTO)));
+    @PatchMapping(value = "/users", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @Operation(summary = "nickname, profile 변경", description = "nickname, profile 변경하는 API입니다.")
+    public ApiResponse<MemberResponseDTO.MemberProfileDTO2> updateProfile(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) @Valid @RequestPart MemberUpdateProfileDTO requestDTO,
+                                                                      @RequestPart("profilePicture") MultipartFile profilePicture,@CurrentMember Member member) throws Exception {
+        return ApiResponse.onSuccess(MemberConverter.toMemberProfileDTO(memberCommandService.updateProfile(member, requestDTO.getNickname(), profilePicture)));
+    }
+
+    @GetMapping("/users")
+    @Operation(summary = "유저 정보 조회", description = "유저정보 조회하는 API입니다.")
+    public ApiResponse<MemberResponseDTO.MemberProfileDTO2> getUser(@CurrentMember Member member) throws Exception {
+        return ApiResponse.onSuccess(MemberConverter.toMemberProfileDTO(member));
+    }
+
+    @PatchMapping("/users/password")
+    @Operation(summary = "password 변경", description = "password 변경하는 API입니다.따옴표 제외!")
+    public ApiResponse<String> updatePassWord(@CurrentMember Member member, @RequestBody String password) throws Exception {
+        memberCommandService.updatePassWord(member, password);
+        return ApiResponse.onSuccess("비밀번호 변경에 성공했습니다.");
     }
 
     @PostMapping("/users/verify-pw")

--- a/src/main/java/com/umc/ttt/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/ttt/domain/member/converter/MemberConverter.java
@@ -22,8 +22,8 @@ public class MemberConverter {
                 .build();
     }
 
-    public static MemberResponseDTO.MemberProfileDTO toMemberProfileDTO(Member member) {
-        return MemberResponseDTO.MemberProfileDTO.builder()
+    public static MemberResponseDTO.MemberProfileDTO2 toMemberProfileDTO(Member member) {
+        return MemberResponseDTO.MemberProfileDTO2.builder()
                 .createdAt(member.getCreatedAt())
                 .id(member.getId())
                 .nickname(member.getNickname())

--- a/src/main/java/com/umc/ttt/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/umc/ttt/domain/member/dto/MemberResponseDTO.java
@@ -34,4 +34,17 @@ public class MemberResponseDTO {
         Role role;
         String accessToken;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberProfileDTO2 {
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+        LocalDateTime createdAt;
+        Long id;
+        String nickname;
+        String profileUrl;
+        Role role;
+    }
 }

--- a/src/main/java/com/umc/ttt/domain/member/dto/MemberUpdateProfileDTO.java
+++ b/src/main/java/com/umc/ttt/domain/member/dto/MemberUpdateProfileDTO.java
@@ -1,5 +1,6 @@
 package com.umc.ttt.domain.member.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,12 +10,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class MemberUpdateInfoDTO {
+public class MemberUpdateProfileDTO {
+    @NotNull(message = "닉네임은 필수입니다.")
     private String nickname;
-
-//    private String profileUrl;
-
-    private String password;
 }
 
 

--- a/src/main/java/com/umc/ttt/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/umc/ttt/domain/member/service/MemberCommandService.java
@@ -28,7 +28,10 @@ public interface MemberCommandService {
 
     Member saveProfile(MemberAddProfileDTO memberProfileDTO, MultipartFile profilePicture) throws Exception;
 
-    Member updateInfo(Member member, MemberUpdateInfoDTO memberUpdateInfoDTO) throws Exception;
+    Member updateProfile(Member member, String nickname, MultipartFile profilePicture) throws Exception;
+
+    void updatePassWord(Member member, String password) throws Exception;
 
     void validatePassword(Member member, String password) throws Exception;
+
 }

--- a/src/main/java/com/umc/ttt/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/umc/ttt/domain/member/service/MemberCommandServiceImpl.java
@@ -15,7 +15,6 @@ import com.umc.ttt.domain.member.entity.enums.ProviderType;
 import com.umc.ttt.domain.member.entity.enums.Role;
 import com.umc.ttt.domain.member.repository.MemberPreferredCategoryRepository;
 import com.umc.ttt.domain.member.repository.MemberRepository;
-import com.umc.ttt.domain.place.entity.enums.PlaceCategory;
 import com.umc.ttt.domain.scrap.entity.ScrapFolder;
 import com.umc.ttt.domain.scrap.repository.ScrapFolderRepository;
 import com.umc.ttt.global.apiPayload.code.status.ErrorStatus;
@@ -257,7 +256,6 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         String pictureUrl = s3Manager.uploadFile(s3Manager.generateProfileKeyName(savedUuid) + "." + getFileExtension(profilePicture.getOriginalFilename()), profilePicture);
 
         member.setProfileUrl(pictureUrl);
-        member.setRole(Role.USER);
         // 변경된 회원 정보 저장
         memberRepository.save(member);
 
@@ -265,25 +263,39 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     }
 
     @Override
-    public Member updateInfo(Member member, MemberUpdateInfoDTO memberUpdateInfoDTO) throws Exception {
+    public Member updateProfile(Member member, String nickname, MultipartFile profilePicture) throws Exception {
         // 닉네임이 제공된 경우 업데이트
-        if (memberUpdateInfoDTO.getNickname() != null) {
-            member.setNickname(memberUpdateInfoDTO.getNickname());
+        log.info(nickname);
+        if (nickname != null) {
+            member.setNickname(nickname);
         }
 
         // 프로필 URL이 제공된 경우 업데이트
-        if (memberUpdateInfoDTO.getProfileUrl() != null) {
-            member.setProfileUrl(memberUpdateInfoDTO.getProfileUrl());
-        }
+        if (profilePicture != null) {
+            String uuid = UUID.randomUUID().toString();
+            Uuid savedUuid = uuidRepository.save(Uuid.builder()
+                    .uuid(uuid).build());
 
-        if (memberUpdateInfoDTO.getPassword() != null){
-            member.setPassword(memberUpdateInfoDTO.getPassword());
-            member.passwordEncode(passwordEncoder);
+            String pictureUrl = s3Manager.uploadFile(s3Manager.generateProfileKeyName(savedUuid) + "." + getFileExtension(profilePicture.getOriginalFilename()), profilePicture);
+
+            //원래 이미지 삭제
+            s3Manager.deleteFile(member.getProfileUrl());
+            
+            member.setProfileUrl(pictureUrl);
         }
         // 변경된 회원 정보 저장
         memberRepository.save(member);
 
         return member;
+    }
+    @Override
+    public void updatePassWord(Member member, String password) throws Exception {
+        if (password != null){
+            member.setPassword(password);
+            member.passwordEncode(passwordEncoder);
+        }
+        // 변경된 회원 정보 저장
+        memberRepository.save(member);
     }
 
     @Override

--- a/src/main/java/com/umc/ttt/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/ttt/global/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -71,6 +72,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(requests -> requests
                         .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/favicon.ico", "/h2-console/**").permitAll() // 정적 리소스 허용
                         .requestMatchers("/api/sign-up", "/api/login").permitAll() // 회원가입 접근 허용
+                        .requestMatchers(HttpMethod.POST, "/api/users").permitAll() // ✅ POST 요청만 허용
                         .requestMatchers(allowedUrls).permitAll() // 추가 허용된 경로
                         .anyRequest().authenticated() // 기타 요청은 인증 필요
                 )


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #100 

## 📝 작업 내용
-   비밀번호 수정과 profile 수정 분리
- 정보 조회 api 구현
- 정보 수정 시 aws s3에서도 해당 프로필 사진 삭제 기능 추가

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
