### PR TITLE
[fix #114] 홈화면-리마인드(서평 가져오기)에서 사용자 서평만 보이도록 오류 수정

### DIFF
--- a/src/main/java/com/umc/ttt/domain/home/converter/HomeConverter.java
+++ b/src/main/java/com/umc/ttt/domain/home/converter/HomeConverter.java
@@ -55,6 +55,7 @@ public class HomeConverter {
 //    리마인드 (독서평)
     public static HomeResponseDTO.remindReviewDTO toRemindReviewDTO(Review review) {
         return HomeResponseDTO.remindReviewDTO.builder()
+                .reviewId(review.getId())
                 .bookId(review.getBook().getId())
                 .bookTitle(review.getBook().getTitle())
                 .bookCover(review.getBook().getCover())

--- a/src/main/java/com/umc/ttt/domain/home/dto/HomeResponseDTO.java
+++ b/src/main/java/com/umc/ttt/domain/home/dto/HomeResponseDTO.java
@@ -62,6 +62,7 @@ public class HomeResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class remindReviewDTO {
+        Long reviewId;
         Long bookId;
         String bookTitle;
         String bookCover;

--- a/src/main/java/com/umc/ttt/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/com/umc/ttt/domain/home/service/HomeServiceImpl.java
@@ -35,7 +35,7 @@ public class HomeServiceImpl implements HomeService{
         List<HomeResponseDTO.recommendBookLetterDTO> recommentBookLetterDTOList = bookLetterCommandService.getRecommendBookLetters(member);
 
         // 리마인드 (독서평)
-        List<HomeResponseDTO.remindReviewDTO> remindReviewDTOList = reviewCommandService.getRandomReviewsByYear();
+        List<HomeResponseDTO.remindReviewDTO> remindReviewDTOList = reviewCommandService.getRandomReviewsByYear(member);
 
         return HomeConverter.toViewHomeResultDTO(nickName, profileUrl , recentBookLetterDTOList, activeBookClubDTOList, recommentBookLetterDTOList, remindReviewDTOList);
     }

--- a/src/main/java/com/umc/ttt/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/umc/ttt/domain/review/repository/ReviewRepository.java
@@ -36,6 +36,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findByBookId(Long bookId);
 
-    @Query("SELECT r FROM Review r WHERE YEAR(r.writeDate) = YEAR(CURRENT_DATE) ORDER BY FUNCTION('RAND')")
-    List<Review> findRandomReviewByYear(Pageable pageable);
+    @Query("SELECT r FROM Review r WHERE YEAR(r.writeDate) = YEAR(CURRENT_DATE) AND r.member = :member ORDER BY FUNCTION('RAND')")
+    List<Review> findRandomReviewByYearAndMember(Pageable pageable, Member member);
 }

--- a/src/main/java/com/umc/ttt/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/com/umc/ttt/domain/review/service/ReviewCommandService.java
@@ -15,5 +15,5 @@ public interface ReviewCommandService {
     List<Review> getReviewCalendar(int year, int month, Member member);
     ReviewResponseDTO.reviewListDTO getReviewList(Long cursor, int limit, Member member);
     Review getReviewInfo(Long reviewId);
-    List<HomeResponseDTO.remindReviewDTO> getRandomReviewsByYear();
+    List<HomeResponseDTO.remindReviewDTO> getRandomReviewsByYear(Member member);
 }

--- a/src/main/java/com/umc/ttt/domain/review/service/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/umc/ttt/domain/review/service/ReviewCommandServiceImpl.java
@@ -228,9 +228,9 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
     // 홈화면 서평 가져오기 (랜덤 5개)
     @Override
     @Transactional(readOnly = true)
-    public List<HomeResponseDTO.remindReviewDTO> getRandomReviewsByYear() {
+    public List<HomeResponseDTO.remindReviewDTO> getRandomReviewsByYear(Member member) {
         Pageable limit = PageRequest.of(0,5);
-        List<Review> reviews = reviewRepository.findRandomReviewByYear(limit);
+        List<Review> reviews = reviewRepository.findRandomReviewByYearAndMember(limit, member);
 
         return reviews.stream()
                 .map(HomeConverter::toRemindReviewDTO).collect(Collectors.toList());


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #114 

## 📝 작업 내용
-  홈화면-리마인드(서평 가져오기)에서 사용자 서평만 보이도록 오류 수정

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
